### PR TITLE
Fix jsonrpc subscriptions

### DIFF
--- a/gethrpc/handler.go
+++ b/gethrpc/handler.go
@@ -282,9 +282,10 @@ func (h *handler) handleResponse(msg *jsonrpcMessage) {
 		op.err = msg.Error
 		return
 	}
-	var subid int
+	var subid string
+
 	if op.err = json.Unmarshal(msg.Result, &subid); op.err == nil {
-		op.sub.subid = fmt.Sprintf("%v", subid)
+		op.sub.subid = subid
 		go op.sub.start()
 		h.clientSubs[op.sub.subid] = op.sub
 	}

--- a/gethrpc/json.go
+++ b/gethrpc/json.go
@@ -39,7 +39,7 @@ const (
 var null = json.RawMessage("null")
 
 type subscriptionResult struct {
-	ID     int             `json:"subscription"`
+	ID     string          `json:"subscription"`
 	Result json.RawMessage `json:"result,omitempty"`
 }
 

--- a/gethrpc/subscription.go
+++ b/gethrpc/subscription.go
@@ -168,7 +168,7 @@ func (n *Notifier) activate() error {
 }
 
 func (n *Notifier) send(sub *Subscription, data json.RawMessage) error {
-	params, _ := json.Marshal(&subscriptionResult{ID: int(sub.ID), Result: data})
+	params, _ := json.Marshal(&subscriptionResult{ID: string(sub.ID), Result: data})
 	ctx := context.Background()
 	return n.h.conn.Write(ctx, &jsonrpcMessage{
 		Version: vsn,

--- a/teste2e/author_submit_and_watch_extrinsic_test.go
+++ b/teste2e/author_submit_and_watch_extrinsic_test.go
@@ -95,6 +95,7 @@ func TestAuthor_SubmitAndWatchExtrinsic(t *testing.T) {
 		GenesisHash: genesisHash,
 		Nonce:       types.NewUCompactFromUInt(uint64(nonce)),
 		SpecVersion: rv.SpecVersion,
+		TxVersion:   1,
 		Tip:         types.NewUCompactFromUInt(0),
 	}
 


### PR DESCRIPTION
It is now an alphanumeric string rather than an integer. See below examples:

Subscription request:
```
{"jsonrpc":"2.0","id":3,"method":"state_subscribeStorage","params":[["0x26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7"]]}
```
Response with subscription ID:
```
{"jsonrpc":"2.0","result":"Fi0OGRHhayI77bgL","id":3}
```

published event with subscription ID `Fi0OGRHhayI77bgL`.
```
{"jsonrpc":"2.0","method":"state_storage","params":{"result":{"block":"0x6a410de4d58043cbfe4209fe48f9c88d1840cf37d1b6eea8294bc403cdb4c30d","changes":[["0x26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7","0x040000000000000080e36a0900000000020000"]]},"subscription":"Fi0OGRHhayI77bgL"}}
```
