### PR TITLE
Event types now include the index of the event in the EventRecord

### DIFF
--- a/types/event_record.go
+++ b/types/event_record.go
@@ -219,11 +219,12 @@ func (e EventRecordsRaw) DecodeEventRecords(m *Metadata, t interface{}) error {
 
 		// ensure first field is for Phase, last field is for Topics
 		numFields := holder.Elem().NumField()
-		if numFields < 2 {
-			return fmt.Errorf("expected event #%v with EventID %v, field %v_%v to have at least 2 fields "+
-				"(for Phase and Topics), but has %v fields", i, id, moduleName, eventName, numFields)
+		if numFields < 3 {
+			return fmt.Errorf("expected event #%v with EventID %v, field %v_%v to have at least 3 fields "+
+				"(for Index, Phase and Topics), but has %v fields", i, id, moduleName, eventName, numFields)
 		}
-		phaseField := holder.Elem().FieldByIndex([]int{0})
+		indexField := holder.Elem().FieldByIndex([]int{0})
+		phaseField := holder.Elem().FieldByIndex([]int{1})
 		if phaseField.Type() != reflect.TypeOf(phase) {
 			return fmt.Errorf("expected the first field of event #%v with EventID %v, field %v_%v to be of type "+
 				"types.Phase, but got %v", i, id, moduleName, eventName, phaseField.Type())
@@ -234,11 +235,13 @@ func (e EventRecordsRaw) DecodeEventRecords(m *Metadata, t interface{}) error {
 				"[]types.Hash for Topics, but got %v", i, id, moduleName, eventName, topicsField.Type())
 		}
 
+		indexField.Set(reflect.ValueOf(i))
+
 		// set the phase we decoded earlier
 		phaseField.Set(reflect.ValueOf(phase))
 
 		// set the remaining fields
-		for j := 1; j < numFields; j++ {
+		for j := 2; j < numFields; j++ {
 			err = decoder.Decode(holder.Elem().FieldByIndex([]int{j}).Addr().Interface())
 			if err != nil {
 				return fmt.Errorf("unable to decode field %v event #%v with EventID %v, field %v_%v: %v", j, i, id, moduleName,

--- a/types/events.go
+++ b/types/events.go
@@ -24,51 +24,57 @@ import (
 
 // EventBalancesEndowed is emitted when an account is created with some free balance
 type EventBalancesEndowed struct {
-	Phase   Phase
-	Who     AccountID
-	Balance U128
-	Topics  []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventDustLost is emitted when an account is removed with a balance that is
 // non-zero but below ExistentialDeposit, resulting in a loss.
 type EventBalancesDustLost struct {
-	Phase   Phase
-	Who     AccountID
-	Balance U128
-	Topics  []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventBalancesTransfer is emitted when a transfer succeeded (from, to, value)
 type EventBalancesTransfer struct {
-	Phase  Phase
-	From   AccountID
-	To     AccountID
-	Value  U128
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	From             AccountID
+	To               AccountID
+	Value            U128
+	Topics           []Hash
 }
 
 // EventBalanceSet is emitted when a balance is set by root
 type EventBalancesBalanceSet struct {
-	Phase    Phase
-	Who      AccountID
-	Free     U128
-	Reserved U128
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Free             U128
+	Reserved         U128
+	Topics           []Hash
 }
 
 // EventDeposit is emitted when an account receives some free balance
 type EventBalancesDeposit struct {
-	Phase   Phase
-	Who     AccountID
-	Balance U128
-	Topics  []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventGrandpaNewAuthorities is emitted when a new authority set has been applied
 type EventGrandpaNewAuthorities struct {
-	Phase          Phase
-	NewAuthorities []struct {
+	EventRecordIndex uint64
+	Phase            Phase
+	NewAuthorities   []struct {
 		AuthorityID     AuthorityID
 		AuthorityWeight U64
 	}
@@ -77,44 +83,51 @@ type EventGrandpaNewAuthorities struct {
 
 // EventGrandpaPaused is emitted when the current authority set has been paused
 type EventGrandpaPaused struct {
-	Phase  Phase
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Topics           []Hash
 }
 
 // EventGrandpaResumed is emitted when the current authority set has been resumed
 type EventGrandpaResumed struct {
-	Phase  Phase
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Topics           []Hash
 }
 
 // EventImOnlineHeartbeatReceived is emitted when a new heartbeat was received from AuthorityId
 type EventImOnlineHeartbeatReceived struct {
-	Phase       Phase
-	AuthorityID AuthorityID
-	Topics      []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	AuthorityID      AuthorityID
+	Topics           []Hash
 }
 
 // EventImOnlineAllGood is emitted when at the end of the session, no offence was committed
 type EventImOnlineAllGood struct {
-	Phase  Phase
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Topics           []Hash
 }
 
 // Exposure lists the own and nominated stake of a validator
 type Exposure struct {
-	Total  UCompact
-	Own    UCompact
-	Others []IndividualExposure
+	EventRecordIndex uint64
+	Total            UCompact
+	Own              UCompact
+	Others           []IndividualExposure
 }
 
 // IndividualExposure contains the nominated stake by one specific third party
 type IndividualExposure struct {
-	Who   AccountID
-	Value UCompact
+	EventRecordIndex uint64
+	Who              AccountID
+	Value            UCompact
 }
 
 // EventImOnlineSomeOffline is emitted when the end of the session, at least once validator was found to be offline
 type EventImOnlineSomeOffline struct {
+	EventRecordIndex     uint64
 	Phase                Phase
 	IdentificationTuples []struct {
 		ValidatorID        AccountID
@@ -125,59 +138,66 @@ type EventImOnlineSomeOffline struct {
 
 // EventIndicesIndexAssigned is emitted when an index is assigned to an AccountID.
 type EventIndicesIndexAssigned struct {
-	Phase        Phase
-	AccountID    AccountID
-	AccountIndex AccountIndex
-	Topics       []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	AccountID        AccountID
+	AccountIndex     AccountIndex
+	Topics           []Hash
 }
 
 // EventIndicesIndexFreed is emitted when an index is unassigned.
 type EventIndicesIndexFreed struct {
-	Phase        Phase
-	AccountIndex AccountIndex
-	Topics       []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	AccountIndex     AccountIndex
+	Topics           []Hash
 }
 
 // EventOffencesOffence is emitted when there is an offence reported of the given kind happened at the session_index
 // and (kind-specific) time slot. This event is not deposited for duplicate slashes
 type EventOffencesOffence struct {
-	Phase          Phase
-	Kind           Bytes16
-	OpaqueTimeSlot Bytes
-	Topics         []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Kind             Bytes16
+	OpaqueTimeSlot   Bytes
+	Topics           []Hash
 }
 
 // EventSessionNewSession is emitted when a new session has happened. Note that the argument is the session index,
 // not the block number as the type might suggest
 type EventSessionNewSession struct {
-	Phase        Phase
-	SessionIndex U32
-	Topics       []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	SessionIndex     U32
+	Topics           []Hash
 }
 
 // EventStakingReward is emitted when all validators have been rewarded by the first balance; the second is the
 // remainder, from the maximum amount of reward.
 type EventStakingReward struct {
-	Phase     Phase
-	Balance   U128
-	Remainder U128
-	Topics    []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Balance          U128
+	Remainder        U128
+	Topics           []Hash
 }
 
 // EventStakingSlash is emitted when one validator (and its nominators) has been slashed by the given amount
 type EventStakingSlash struct {
-	Phase     Phase
-	AccountID AccountID
-	Balance   U128
-	Topics    []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	AccountID        AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventStakingOldSlashingReportDiscarded is emitted when an old slashing report from a prior era was discarded because
 // it could not be processed
 type EventStakingOldSlashingReportDiscarded struct {
-	Phase        Phase
-	SessionIndex U32
-	Topics       []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	SessionIndex     U32
+	Topics           []Hash
 }
 
 // EventSystemExtrinsicSuccessV8 is emitted when an extrinsic completed successfully
@@ -185,15 +205,17 @@ type EventStakingOldSlashingReportDiscarded struct {
 // Deprecated: EventSystemExtrinsicSuccessV8 exists to allow users to simply implement their own EventRecords struct if
 // they are on metadata version 8 or below. Use EventSystemExtrinsicSuccess otherwise
 type EventSystemExtrinsicSuccessV8 struct {
-	Phase  Phase
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Topics           []Hash
 }
 
 // EventSystemExtrinsicSuccess is emitted when an extrinsic completed successfully
 type EventSystemExtrinsicSuccess struct {
-	Phase        Phase
-	DispatchInfo DispatchInfo
-	Topics       []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	DispatchInfo     DispatchInfo
+	Topics           []Hash
 }
 
 // DispatchInfo contains a bundle of static information collected from the `#[weight = $x]` attributes.
@@ -245,88 +267,99 @@ func (d DispatchClass) Encode(encoder scale.Encoder) error {
 // Deprecated: EventSystemExtrinsicFailedV8 exists to allow users to simply implement their own EventRecords struct if
 // they are on metadata version 8 or below. Use EventSystemExtrinsicFailed otherwise
 type EventSystemExtrinsicFailedV8 struct {
-	Phase         Phase
-	DispatchError DispatchError
-	Topics        []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	DispatchError    DispatchError
+	Topics           []Hash
 }
 
 // EventSystemExtrinsicFailed is emitted when an extrinsic failed
 type EventSystemExtrinsicFailed struct {
-	Phase         Phase
-	DispatchError DispatchError
-	DispatchInfo  DispatchInfo
-	Topics        []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	DispatchError    DispatchError
+	DispatchInfo     DispatchInfo
+	Topics           []Hash
 }
 
 // EventSystemCodeUpdated is emitted when the runtime code (`:code`) is updated
 type EventSystemCodeUpdated struct {
-	Phase  Phase
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Topics           []Hash
 }
 
 // EventSystemNewAccount is emitted when a new account was created
 type EventSystemNewAccount struct {
-	Phase  Phase
-	Who    AccountID
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Topics           []Hash
 }
 
 // EventSystemKilledAccount is emitted when an account is reaped
 type EventSystemKilledAccount struct {
-	Phase  Phase
-	Who    AccountID
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Topics           []Hash
 }
 
 // EventAssetIssued is emitted when an asset is issued.
 type EventAssetIssued struct {
-	Phase   Phase
-	AssetID U32
-	Who     AccountID
-	Balance U128
-	Topics  []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	AssetID          U32
+	Who              AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventAssetTransferred is emitted when an asset is transferred.
 type EventAssetTransferred struct {
-	Phase   Phase
-	AssetID U32
-	To      AccountID
-	From    AccountID
-	Balance U128
-	Topics  []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	AssetID          U32
+	To               AccountID
+	From             AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventAssetDestroyed is emitted when an asset is destroyed.
 type EventAssetDestroyed struct {
-	Phase   Phase
-	AssetID U32
-	Who     AccountID
-	Balance U128
-	Topics  []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	AssetID          U32
+	Who              AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventDemocracyProposed is emitted when a motion has been proposed by a public account.
 type EventDemocracyProposed struct {
-	Phase         Phase
-	ProposalIndex U32
-	Balance       U128
-	Topics        []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	ProposalIndex    U32
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventDemocracyTabled is emitted when a public proposal has been tabled for referendum vote.
 type EventDemocracyTabled struct {
-	Phase         Phase
-	ProposalIndex U32
-	Balance       U128
-	Accounts      []AccountID
-	Topics        []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	ProposalIndex    U32
+	Balance          U128
+	Accounts         []AccountID
+	Topics           []Hash
 }
 
 // EventDemocracyExternalTabled is emitted when an external proposal has been tabled.
 type EventDemocracyExternalTabled struct {
-	Phase  Phase
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Topics           []Hash
 }
 
 // VoteThreshold is a means of determining if a vote is past pass threshold.
@@ -359,178 +392,199 @@ func (v VoteThreshold) Encode(encoder scale.Encoder) error {
 
 // EventDemocracyStarted is emitted when a referendum has begun.
 type EventDemocracyStarted struct {
-	Phase           Phase
-	ReferendumIndex U32
-	VoteThreshold   VoteThreshold
-	Topics          []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	ReferendumIndex  U32
+	VoteThreshold    VoteThreshold
+	Topics           []Hash
 }
 
 // EventDemocracyPassed is emitted when a proposal has been approved by referendum.
 type EventDemocracyPassed struct {
-	Phase           Phase
-	ReferendumIndex U32
-	Topics          []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	ReferendumIndex  U32
+	Topics           []Hash
 }
 
 // EventDemocracyNotPassed is emitted when a proposal has been rejected by referendum.
 type EventDemocracyNotPassed struct {
-	Phase           Phase
-	ReferendumIndex U32
-	Topics          []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	ReferendumIndex  U32
+	Topics           []Hash
 }
 
 // EventDemocracyCancelled is emitted when a referendum has been cancelled.
 type EventDemocracyCancelled struct {
-	Phase           Phase
-	ReferendumIndex U32
-	Topics          []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	ReferendumIndex  U32
+	Topics           []Hash
 }
 
 // EventDemocracyExecuted is emitted when a proposal has been enacted.
 type EventDemocracyExecuted struct {
-	Phase           Phase
-	ReferendumIndex U32
-	Result          bool
-	Topics          []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	ReferendumIndex  U32
+	Result           bool
+	Topics           []Hash
 }
 
 // EventDemocracyDelegated is emitted when an account has delegated their vote to another account.
 type EventDemocracyDelegated struct {
-	Phase  Phase
-	Who    AccountID
-	Target AccountID
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Target           AccountID
+	Topics           []Hash
 }
 
 // EventDemocracyUndelegated is emitted when an account has cancelled a previous delegation operation.
 type EventDemocracyUndelegated struct {
-	Phase  Phase
-	Target AccountID
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Target           AccountID
+	Topics           []Hash
 }
 
 // EventDemocracyVetoed is emitted when an external proposal has been vetoed.
 type EventDemocracyVetoed struct {
-	Phase       Phase
-	Who         AccountID
-	Hash        Hash
-	BlockNumber BlockNumber
-	Topics      []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Hash             Hash
+	BlockNumber      BlockNumber
+	Topics           []Hash
 }
 
 // EventDemocracyPreimageNoted is emitted when a proposal's preimage was noted, and the deposit taken.
 type EventDemocracyPreimageNoted struct {
-	Phase     Phase
-	Hash      Hash
-	AccountID AccountID
-	Balance   U128
-	Topics    []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Hash             Hash
+	AccountID        AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventDemocracyPreimageUsed is emitted when a proposal preimage was removed and used (the deposit was returned).
 type EventDemocracyPreimageUsed struct {
-	Phase     Phase
-	Hash      Hash
-	AccountID AccountID
-	Balance   U128
-	Topics    []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Hash             Hash
+	AccountID        AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventDemocracyPreimageInvalid is emitted when a proposal could not be executed because its preimage was invalid.
 type EventDemocracyPreimageInvalid struct {
-	Phase           Phase
-	Hash            Hash
-	ReferendumIndex U32
-	Topics          []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Hash             Hash
+	ReferendumIndex  U32
+	Topics           []Hash
 }
 
 // EventDemocracyPreimageMissing is emitted when a proposal could not be executed because its preimage was missing.
 type EventDemocracyPreimageMissing struct {
-	Phase           Phase
-	Hash            Hash
-	ReferendumIndex U32
-	Topics          []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Hash             Hash
+	ReferendumIndex  U32
+	Topics           []Hash
 }
 
 // EventDemocracyPreimageReaped is emitted when a registered preimage was removed
 // and the deposit collected by the reaper (last item).
 type EventDemocracyPreimageReaped struct {
-	Phase    Phase
-	Hash     Hash
-	Provider AccountID
-	Balance  U128
-	Who      AccountID
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Hash             Hash
+	Provider         AccountID
+	Balance          U128
+	Who              AccountID
+	Topics           []Hash
 }
 
 // EventDemocracyUnlocked is emitted when an account has been unlocked successfully.
 type EventDemocracyUnlocked struct {
-	Phase     Phase
-	AccountID AccountID
-	Topics    []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	AccountID        AccountID
+	Topics           []Hash
 }
 
 // EventCollectiveProposed is emitted when a motion (given hash) has been proposed (by given account)
 // with a threshold (given `MemberCount`).
 type EventCollectiveProposed struct {
-	Phase         Phase
-	Who           AccountID
-	ProposalIndex U32
-	Proposal      Hash
-	MemberCount   U32
-	Topics        []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	ProposalIndex    U32
+	Proposal         Hash
+	MemberCount      U32
+	Topics           []Hash
 }
 
 // EventCollectiveVote is emitted when a motion (given hash) has been voted on by given account, leaving
 // a tally (yes votes and no votes given respectively as `MemberCount`).
 type EventCollectiveVoted struct {
-	Phase    Phase
-	Who      AccountID
-	Proposal Hash
-	Approve  bool
-	YesCount U32
-	NoCount  U32
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Proposal         Hash
+	Approve          bool
+	YesCount         U32
+	NoCount          U32
+	Topics           []Hash
 }
 
 // EventCollectiveApproved is emitted when a motion was approved by the required threshold.
 type EventCollectiveApproved struct {
-	Phase    Phase
-	Proposal Hash
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Proposal         Hash
+	Topics           []Hash
 }
 
 // EventCollectiveDisapproved is emitted when a motion was not approved by the required threshold.
 type EventCollectiveDisapproved struct {
-	Phase    Phase
-	Proposal Hash
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Proposal         Hash
+	Topics           []Hash
 }
 
 // EventCollectiveExecuted is emitted when a motion was executed; `bool` is true if returned without error.
 type EventCollectiveExecuted struct {
-	Phase    Phase
-	Proposal Hash
-	Ok       bool
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Proposal         Hash
+	Ok               bool
+	Topics           []Hash
 }
 
 // EventCollectiveMemberExecuted is emitted when a single member did some action;
 // `bool` is true if returned without error.
 type EventCollectiveMemberExecuted struct {
-	Phase    Phase
-	Proposal Hash
-	Ok       bool
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Proposal         Hash
+	Ok               bool
+	Topics           []Hash
 }
 
 // EventCollectiveClosed is emitted when a proposal was closed after its duration was up.
 type EventCollectiveClosed struct {
-	Phase    Phase
-	Proposal Hash
-	YesCount U32
-	NoCount  U32
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Proposal         Hash
+	YesCount         U32
+	NoCount          U32
+	Topics           []Hash
 }
 
 // EventElectionsNewTerm is emitted when a new term with new members.
@@ -547,28 +601,32 @@ type EventElectionsNewTerm struct {
 
 // EventElectionsEmpty is emitted when No (or not enough) candidates existed for this round.
 type EventElectionsEmptyTerm struct {
-	Phase  Phase
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Topics           []Hash
 }
 
 // EventElectionsMemberKicked is emitted when a member has been removed.
 // This should always be followed by either `NewTerm` or `EmptyTerm`.
 type EventElectionsMemberKicked struct {
-	Phase  Phase
-	Member AccountID
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Member           AccountID
+	Topics           []Hash
 }
 
 // EventElectionsMemberRenounced is emitted when a member has renounced their candidacy.
 type EventElectionsMemberRenounced struct {
-	Phase  Phase
-	Member AccountID
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Member           AccountID
+	Topics           []Hash
 }
 
 // EventElectionsVoterReported is emitted when a voter (first element) was reported (by the second element)
 // with the the report being successful or not (third element).
 type EventElectionsVoterReported struct {
+	EventRecordIndex uint64
 	Phase            Phase
 	Target, Reporter AccountID
 	Valid            bool
@@ -577,228 +635,258 @@ type EventElectionsVoterReported struct {
 
 // A name was set or reset (which will remove all judgements).
 type EventIdentitySet struct {
-	Phase    Phase
-	Identity AccountID
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Identity         AccountID
+	Topics           []Hash
 }
 
 // A name was cleared, and the given balance returned.
 type EventIdentityCleared struct {
-	Phase    Phase
-	Identity AccountID
-	Balance  U128
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Identity         AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // A name was removed and the given balance slashed.
 type EventIdentityKilled struct {
-	Phase    Phase
-	Identity AccountID
-	Balance  U128
-	Topics   []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Identity         AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // A judgement was asked from a registrar.
 type EventIdentityJudgementRequested struct {
-	Phase          Phase
-	Sender         AccountID
-	RegistrarIndex U32
-	Topics         []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Sender           AccountID
+	RegistrarIndex   U32
+	Topics           []Hash
 }
 
 // A judgement request was retracted.
 type EventIdentityJudgementUnrequested struct {
-	Phase          Phase
-	Sender         AccountID
-	RegistrarIndex U32
-	Topics         []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Sender           AccountID
+	RegistrarIndex   U32
+	Topics           []Hash
 }
 
 // A judgement was given by a registrar.
 type EventIdentityJudgementGiven struct {
-	Phase          Phase
-	Target         AccountID
-	RegistrarIndex U32
-	Topics         []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Target           AccountID
+	RegistrarIndex   U32
+	Topics           []Hash
 }
 
 // A registrar was added.
 type EventIdentityRegistrarAdded struct {
-	Phase          Phase
-	RegistrarIndex U32
-	Topics         []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	RegistrarIndex   U32
+	Topics           []Hash
 }
 
 // EventRecoveryCreated is emitted when a recovery process has been set up for an account
 type EventRecoveryCreated struct {
-	Phase  Phase
-	Who    AccountID
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Topics           []Hash
 }
 
 // EventRecoveryInitiated is emitted when a recovery process has been initiated for account_1 by account_2
 type EventRecoveryInitiated struct {
-	Phase   Phase
-	Account AccountID
-	Who     AccountID
-	Topics  []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Account          AccountID
+	Who              AccountID
+	Topics           []Hash
 }
 
 // EventRecoveryVouched is emitted when a recovery process for account_1 by account_2 has been vouched for by account_3
 type EventRecoveryVouched struct {
-	Phase   Phase
-	Lost    AccountID
-	Rescuer AccountID
-	Who     AccountID
-	Topics  []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Lost             AccountID
+	Rescuer          AccountID
+	Who              AccountID
+	Topics           []Hash
 }
 
 // EventRecoveryClosed is emitted when a recovery process for account_1 by account_2 has been closed
 type EventRecoveryClosed struct {
-	Phase   Phase
-	Who     AccountID
-	Rescuer AccountID
-	Topics  []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Rescuer          AccountID
+	Topics           []Hash
 }
 
 // EventRecoveryAccountRecovered is emitted when account_1 has been successfully recovered by account_2
 type EventRecoveryAccountRecovered struct {
-	Phase   Phase
-	Who     AccountID
-	Rescuer AccountID
-	Topics  []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Rescuer          AccountID
+	Topics           []Hash
 }
 
 // EventRecoveryRemoved is emitted when a recovery process has been removed for an account
 type EventRecoveryRemoved struct {
-	Phase  Phase
-	Who    AccountID
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	Topics           []Hash
 }
 
 // EventSudoSudid is emitted when a sudo just took place.
 type EventSudoSudid struct {
-	Phase  Phase
-	Result bool
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Result           bool
+	Topics           []Hash
 }
 
 // EventSudoKeyChanged is emitted when the sudoer just switched identity; the old key is supplied.
 type EventSudoKeyChanged struct {
-	Phase     Phase
-	AccountID AccountID
-	Topics    []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	AccountID        AccountID
+	Topics           []Hash
 }
 
 // A sudo just took place.
 type EventSudoAsDone struct {
-	Phase  Phase
-	Done   bool
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Done             bool
+	Topics           []Hash
 }
 
 // EventTreasuryProposed is emitted when New proposal.
 type EventTreasuryProposed struct {
-	Phase         Phase
-	ProposalIndex U32
-	Topics        []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	ProposalIndex    U32
+	Topics           []Hash
 }
 
 // EventTreasurySpending is emitted when we have ended a spend period and will now allocate funds.
 type EventTreasurySpending struct {
-	Phase           Phase
-	BudgetRemaining U128
-	Topics          []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	BudgetRemaining  U128
+	Topics           []Hash
 }
 
 // EventTreasuryAwarded is emitted when some funds have been allocated.
 type EventTreasuryAwarded struct {
-	Phase         Phase
-	ProposalIndex U32
-	Amount        U128
-	Beneficiary   AccountID
-	Topics        []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	ProposalIndex    U32
+	Amount           U128
+	Beneficiary      AccountID
+	Topics           []Hash
 }
 
 // EventTreasuryRejected is emitted when s proposal was rejected; funds were slashed.
 type EventTreasuryRejected struct {
-	Phase         Phase
-	ProposalIndex U32
-	Amount        U128
-	Topics        []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	ProposalIndex    U32
+	Amount           U128
+	Topics           []Hash
 }
 
 // EventTreasuryBurnt is emitted when some of our funds have been burnt.
 type EventTreasuryBurnt struct {
-	Phase  Phase
-	Burn   U128
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Burn             U128
+	Topics           []Hash
 }
 
 // EventTreasuryRollover is emitted when spending has finished; this is the amount that rolls over until next spend.
 type EventTreasuryRollover struct {
-	Phase           Phase
-	BudgetRemaining U128
-	Topics          []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	BudgetRemaining  U128
+	Topics           []Hash
 }
 
 // EventTreasuryDeposit is emitted when some funds have been deposited.
 type EventTreasuryDeposit struct {
-	Phase     Phase
-	Deposited U128
-	Topics    []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Deposited        U128
+	Topics           []Hash
 }
 
 // EventTreasuryNewTip is emitted when a new tip suggestion has been opened.
 type EventTreasuryNewTip struct {
-	Phase  Phase
-	Hash   Hash
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Hash             Hash
+	Topics           []Hash
 }
 
 // EventTreasuryTipClosing is emitted when a tip suggestion has reached threshold and is closing.
 type EventTreasuryTipClosing struct {
-	Phase  Phase
-	Hash   Hash
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Hash             Hash
+	Topics           []Hash
 }
 
 // EventTreasuryTipClosed is emitted when a tip suggestion has been closed.
 type EventTreasuryTipClosed struct {
-	Phase     Phase
-	Hash      Hash
-	AccountID AccountID
-	Balance   U128
-	Topics    []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Hash             Hash
+	AccountID        AccountID
+	Balance          U128
+	Topics           []Hash
 }
 
 // EventTreasuryTipRetracted is emitted when a tip suggestion has been retracted.
 type EventTreasuryTipRetracted struct {
-	Phase  Phase
-	Hash   Hash
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Hash             Hash
+	Topics           []Hash
 }
 
 // EventUtilityBatchInterrupted is emitted when a batch of dispatches did not complete fully.
-//Index of first failing dispatch given, as well as the error.
+//EventRecordIndex of first failing dispatch given, as well as the error.
 type EventUtilityBatchInterrupted struct {
-	Phase         Phase
-	Index         U32
-	DispatchError DispatchError
-	Topics        []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Index            U32
+	DispatchError    DispatchError
+	Topics           []Hash
 }
 
 // EventUtilityBatchCompleted is emitted when a batch of dispatches completed fully with no error.
 type EventUtilityBatchCompleted struct {
-	Phase  Phase
-	Topics []Hash
+	EventRecordIndex uint64
+	Phase            Phase
+	Topics           []Hash
 }
 
 // EventUtilityNewMultisig is emitted when a new multisig operation has begun.
 // First param is the account that is approving, second is the multisig account, third is hash of the call.
 type EventUtilityNewMultisig struct {
-	Phase   Phase
-	Who, ID AccountID
+	EventRecordIndex uint64
+	Phase            Phase
+	Who, ID          AccountID
 	// TODO Get CallHash back on for newer versions of substrate
 	//CallHash Hash
 	Topics []Hash
@@ -814,10 +902,11 @@ type TimePoint struct {
 // EventUtility is emitted when a multisig operation has been approved by someone. First param is the account that is
 // approving, third is the multisig account, fourth is hash of the call.
 type EventUtilityMultisigApproval struct {
-	Phase     Phase
-	Who       AccountID
-	TimePoint TimePoint
-	ID        AccountID
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	TimePoint        TimePoint
+	ID               AccountID
 	// TODO Get CallHash back on for newer versions of substrate
 	//CallHash  Hash
 	Topics []Hash
@@ -860,10 +949,11 @@ func (d DispatchResult) Encode(encoder scale.Encoder) error {
 // EventUtility is emitted when a multisig operation has been executed. First param is the account that is
 // approving, third is the multisig account, fourth is hash of the call to be executed.
 type EventUtilityMultisigExecuted struct {
-	Phase     Phase
-	Who       AccountID
-	TimePoint TimePoint
-	ID        AccountID
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	TimePoint        TimePoint
+	ID               AccountID
 	// TODO Get CallHash back on for newer versions of substrate
 	//CallHash  Hash
 	Result DispatchResult
@@ -873,10 +963,11 @@ type EventUtilityMultisigExecuted struct {
 // EventUtility is emitted when a multisig operation has been cancelled. First param is the account that is
 // cancelling, third is the multisig account, fourth is hash of the call.
 type EventUtilityMultisigCancelled struct {
-	Phase     Phase
-	Who       AccountID
-	TimePoint TimePoint
-	ID        AccountID
+	EventRecordIndex uint64
+	Phase            Phase
+	Who              AccountID
+	TimePoint        TimePoint
+	ID               AccountID
 	// TODO Get CallHash back on for newer versions of substrate
 	//CallHash  Hash
 	Topics []Hash


### PR DESCRIPTION
This is the useful for two reasons:
* Our relay can ensure correct event ordering when relaying events that have been decoded from an `EventRecord`.
* The event index is useful for implementing replay protection.