### PR TITLE
Generate MMR proof

### DIFF
--- a/teste2e/generate_mmr_proof_test.go
+++ b/teste2e/generate_mmr_proof_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 type LeafProof struct {
-	BlockHash types.U256
+	BlockHash types.Hash
 	Leaf      []byte
 	Proof     []byte
 }

--- a/teste2e/generate_mmr_proof_test.go
+++ b/teste2e/generate_mmr_proof_test.go
@@ -1,0 +1,67 @@
+// Go Substrate RPC Client (GSRPC) provides APIs and types around Polkadot and any Substrate-based chain RPC calls
+//
+// Copyright 2019 Centrifuge GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package teste2e
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	gsrpc "github.com/snowfork/go-substrate-rpc-client/v2"
+	"github.com/snowfork/go-substrate-rpc-client/v2/config"
+	"github.com/snowfork/go-substrate-rpc-client/v2/types"
+)
+
+type LeafProof struct {
+	BlockHash types.U256
+	Leaf      []byte
+	Proof     []byte
+}
+
+func TestGenerateMMRProof(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end test in short mode.")
+	}
+
+	api, err := gsrpc.NewSubstrateAPI(config.Default().RPCURL)
+	if err != nil {
+		panic(err)
+	}
+
+	blockHashLatest, err := api.RPC.Chain.GetBlockHashLatest()
+	if err != nil {
+		panic(err)
+	}
+
+	block, err := api.RPC.Chain.GetBlock(blockHashLatest)
+	if err != nil {
+		panic(err)
+	}
+
+	blockNumberBytes := make([]byte, 32)
+	binary.LittleEndian.PutUint64(blockNumberBytes, uint64(block.Block.Header.Number))
+	blockNumberStr := hex.EncodeToString(blockNumberBytes[:])
+	blockNumberHexPrefixed := "0x" + blockNumberStr
+
+	leafProof := LeafProof{}
+	err = api.Client.Call(&leafProof, "mmr_generateProof", 0, blockNumberHexPrefixed)
+	if err != nil {
+		panic(err)
+	}
+
+	t.Log("Leaf proof:", leafProof)
+}


### PR DESCRIPTION
_Goal:_ Query `mmr_generateProof`. Relevant RPC methods are defined [here](https://github.com/paritytech/substrate/blob/master/frame/merkle-mountain-range/rpc/src/lib.rs).

_Set up:_ Start services as described [here](https://github.com/Snowfork/polkadot-ethereum/blob/0c6ba310849b9d0f5a971f05ba1d7f9d0c22d111/test/README.md).

_Error:_
```
2021/03/16 13:26:19 Connecting to ws://127.0.0.1:9944...
--- FAIL: TestGenerateMMRProof (0.02s)
panic: Runtime trapped [recovered]
	panic: Runtime trapped
```