### PR TITLE
Deserialize justifications using chain_getBlock api

### DIFF
--- a/types/extrinsic.go
+++ b/types/extrinsic.go
@@ -336,6 +336,20 @@ func (a *Args) Decode(decoder scale.Decoder) error {
 
 type Justification []Bytes
 
+func (j Justification) EngineId() string {
+	if len(j) > 0 {
+		return string(j[0])
+	}
+	return ""
+}
+
+func (j Justification) Payload() Bytes {
+	if len(j) > 1 {
+		return j[1]
+	}
+	return nil
+}
+
 type SignaturePayload struct {
 	Address        Address
 	BlockHash      Hash

--- a/types/extrinsic.go
+++ b/types/extrinsic.go
@@ -336,7 +336,7 @@ func (a *Args) Decode(decoder scale.Decoder) error {
 
 type Justification []Bytes
 
-func (j Justification) EngineId() string {
+func (j Justification) EngineID() string {
 	if len(j) > 0 {
 		return string(j[0])
 	}

--- a/types/extrinsic.go
+++ b/types/extrinsic.go
@@ -334,7 +334,7 @@ func (a *Args) Decode(decoder scale.Decoder) error {
 	return nil
 }
 
-type Justification Bytes
+type Justification []Bytes
 
 type SignaturePayload struct {
 	Address        Address

--- a/types/signed_block.go
+++ b/types/signed_block.go
@@ -17,8 +17,8 @@
 package types
 
 type SignedBlock struct {
-	Block         Block         `json:"block"`
-	Justification Justification `json:"justification"`
+	Block          Block           `json:"block"`
+	Justifications []Justification `json:"justifications"`
 }
 
 // Block encoded with header and extrinsics

--- a/types/storage_key.go
+++ b/types/storage_key.go
@@ -235,4 +235,3 @@ func createKey(meta *Metadata, method, prefix string, stringKey, arg []byte, ent
 func createPrefixedKey(method, prefix string) []byte {
 	return append(xxhash.New128([]byte(prefix)).Sum(nil), xxhash.New128([]byte(method)).Sum(nil)...)
 }
-


### PR DESCRIPTION
### Info
When using the RPC api `chain_getBlock`.
```
curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "chain_getBlock", "params":["0x8e5bcc294c187ee2e17460efab3dc2e245d223365fa118a87204f977d6e84eee"]}' http://localhost:9933
```
Justifications are returned as 3-dimensional array.
```
"justifications":[
  [
    [66,69,69,70],
    [
1,205,231,252,162,5,2,204,76,91,97,143,157,43,99,135,228,238,184,222,146,252,62,98,157,17,108,140,176,113,152,75,54,57,0,0,0,0,0,0,0,0,0,0,0,12,1,201,79,89,176,186,54,170,126,177,22,60,142,25,8,186,180,46,92,238,77,19,103,169,104,212,136,62,131,205,189,122,113,28,167,171,255,19,138,36,57,168,94,42,89,159,168,84,153,230,175,28,214,100,231,22,116,167,43,48,4,185,187,47,147,0,1,226,179,91,48,92,123,140,138,11,49,47,64,8,120,139,236,192,49,39,131,181,66,183,66,15,63,184,73,248,32,73,210,114,166,194,154,182,158,242,224,116,123,115,133,228,170,178,9,220,158,162,153,65,204,233,18,52,166,18,217,54,180,149,26,0,1,183,200,217,126,158,225,88,147,76,12,199,97,227,12,178,155,105,161,81,78,18,123,137,2,56,116,30,9,165,187,200,72,87,252,117,209,83,195,122,192,128,180,209,64,198,217,56,110,90,69,71,138,188,150,177,155,222,137,112,33,216,157,152,138,0
    ]
  ]
]
```
This change is to make sure the json is successfully deserialised as well as adding some helper functions to query a justifications engineId and payload.

### Testing
* Running the tests with and without my changes produce the same set of failures.
* Snowbridge e2e tests pass.